### PR TITLE
add proxy function definition for gbm_bo_get_fd_for_plane

### DIFF
--- a/jammy/arm64/VIM4/wayland/src/README.md
+++ b/jammy/arm64/VIM4/wayland/src/README.md
@@ -5,7 +5,7 @@ To compile the code, do
 ```
 sudo apt-get install libdrm-dev patchelf
 
-gcc -Wall -O2 -fpic -shared gbm_bo_create_with_modifiers2.c -o mali_shim.so
+gcc -Wall -O2 -fpic -shared gbm_symbols_proxy.c -o mali_shim.so
 ```
 
 Then I have used patchelf to add mali_shim.so file as dependency for libMali.so. This ensures that we have a fallback implementation available at runtime for the missing function without having to patch any other programs.

--- a/jammy/arm64/VIM4/wayland/src/gbm_symbols_proxy.c
+++ b/jammy/arm64/VIM4/wayland/src/gbm_symbols_proxy.c
@@ -2,6 +2,12 @@
 #include <libdrm/drm_fourcc.h>
 #include "gbm.h"
 
+int gbm_bo_get_fd_for_plane(struct gbm_bo *bo, int plane)
+{
+  // ignore the plane
+  return gbm_bo_get_fd(bo);
+}
+
 struct gbm_bo *
 gbm_bo_create_with_modifiers2(struct gbm_device *gbm,
                               uint32_t width, uint32_t height,


### PR DESCRIPTION
We were having the same issue as you. And I saw your solution by simply patching it. I took the liberty to add additional missing gbm symbol that we saw in our use case. 

So we needed to have both `gbm_bo_get_fd_for_plane` and `gbm_bo_create_with_modifiers2` so I added it to the `c` file you created and renamed it to something more generic. 

For the missing api just fall back to gbm_bo_get_fd directly. Please see the discussion in https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/946 to get details